### PR TITLE
feat: Enhance network interface selection with type detection and improved UX

### DIFF
--- a/src/utils/interfaceSelector.ts
+++ b/src/utils/interfaceSelector.ts
@@ -26,10 +26,10 @@ export async function selectNetworkInterface(): Promise<string | null> {
     const interfaces = getNetworkInterfaces();
     if (interfaces.length > 0) {
       const defaultAddress = interfaces[0].broadcast;
-      console.error(`📡 ${reason} detected, using first available interface broadcast address: ${defaultAddress}`);
+      console.log(`📡 ${reason} detected, using first available interface broadcast address: ${defaultAddress}`);
       return defaultAddress;
     } else {
-      console.error(`📡 ${reason} detected, no network interfaces found, using default broadcast address: 255.255.255.255`);
+      console.log(`📡 ${reason} detected, no network interfaces found, using default broadcast address: 255.255.255.255`);
     }
     return '255.255.255.255';
   }


### PR DESCRIPTION
## Summary
- Enhanced network interface selection with intelligent type detection and sorting
- Removed unicast options to show only broadcast addresses suitable for Art-Net DMX
- Added visual indicators with emoji icons for different interface types
- Changed default selection to prioritize Ethernet connections over global broadcast
- Fixed launcher hanging when stdout is redirected to log files

## Key Changes

### Interface Type Detection & Sorting
- **Type Detection**: Uses `networksetup -listallhardwareports` on macOS to identify WiFi vs Ethernet vs USB Ethernet interfaces
- **Broadcast-Only Options**: Removed unicast options, showing only broadcast addresses and localhost
- **Intelligent Sorting**: Orders interfaces by reliability - Ethernet first, WiFi second, localhost third, global broadcast last
- **Visual Indicators**: Added emoji icons (🌐 Ethernet, 📶 WiFi, 🏠 Localhost, 🌍 Global)
- **Smart Defaults**: Default selection now chooses first option (typically most reliable interface) instead of global broadcast

### TTY Detection & Fallback
- **Auto-detection**: Detects when stdout is redirected (non-TTY) and automatically selects default
- **Non-interactive Mode**: Supports CI/testing environments with `NON_INTERACTIVE=true`
- **Graceful Fallback**: Falls back to global broadcast when interface selection fails

## Benefits
- **Better User Experience**: Clear visual distinction between interface types
- **More Reliable Defaults**: Prioritizes wired connections for DMX transmission
- **Cleaner Interface**: Only shows relevant broadcast options for Art-Net
- **Robust Operation**: Works in both interactive and automated environments
- **Consistent Behavior**: Matches the enhanced LacyLights.app launcher experience

## Interface Selection Example
```
Available Network Interface Options:
============================================================
[1] 🌐 en21 - Ethernet Broadcast (192.168.7.255)  ← DEFAULT
[2] 📶 en0 - Wifi Broadcast (192.168.7.255)
[3] 🏠 Localhost (for testing only)
[4] 🌍 Global Broadcast (255.255.255.255)
============================================================

📡 Select Art-Net broadcast destination:
   (This determines where DMX data will be sent)
   Press Enter for default (first option)
```

## Test Plan
- [x] Verify interface type detection works correctly (en0 as WiFi, en21 as USB Ethernet)
- [x] Confirm only broadcast addresses are shown (no unicast options)
- [x] Test sorting order: Ethernet → WiFi → Localhost → Global Broadcast
- [x] Verify default selection uses first option instead of global broadcast
- [x] Test TTY detection and automatic fallback when stdout redirected
- [x] Ensure backward compatibility with existing Art-Net functionality

🤖 Generated with [Claude Code](https://claude.ai/code)