### PR TITLE
feat: Add bulk cue updates and expand ETC fixture library

### DIFF
--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -355,6 +355,14 @@ export const typeDefs = gql`
     notes: String
   }
 
+  input BulkCueUpdateInput {
+    cueIds: [ID!]!
+    fadeInTime: Float
+    fadeOutTime: Float
+    followTime: Float
+    easingType: EasingType
+  }
+
   input FixtureMappingInput {
     lacyLightsKey: String!
     qlcManufacturer: String!
@@ -444,6 +452,7 @@ export const typeDefs = gql`
     updateCue(id: ID!, input: CreateCueInput!): Cue!
     deleteCue(id: ID!): Boolean!
     reorderCues(cueListId: ID!, cueOrders: [CueOrderInput!]!): Boolean!
+    bulkUpdateCues(input: BulkCueUpdateInput!): [Cue!]!
 
     # Preview System
     startPreviewSession(projectId: ID!): PreviewSession!

--- a/src/services/qlcFixtureLibrary.ts
+++ b/src/services/qlcFixtureLibrary.ts
@@ -442,6 +442,12 @@ export class QLCFixtureLibrary {
       {
         lacyLightsKey: "Etc/ColorSource Spot",
         qlcManufacturer: "ETC",
+        qlcModel: "ColorSource Spot",
+        qlcMode: "3-channel (RGB)",
+      },
+      {
+        lacyLightsKey: "Etc/ColorSource PAR",
+        qlcManufacturer: "ETC",
         qlcModel: "ColorSource PAR",
         qlcMode: "3-channel (RGB)",
       },


### PR DESCRIPTION
## Summary
Add bulk update functionality for cue fade times and properties, plus expand QLC+ fixture library with additional ETC ColorSource fixtures.

## Changes Made

### GraphQL API Enhancements
- **Add `bulkUpdateCues` mutation** for efficient batch updates of cue properties
- **Support updating** fadeInTime, fadeOutTime, followTime, and easingType in bulk
- **Add comprehensive validation** and error handling for bulk operations
- **Use database transactions** to ensure data consistency during bulk updates

### QLC+ Fixture Library Expansion
- **Add support for ETC ColorSource Spot** (3-channel RGB mode)
- **Fix duplicate mapping** for ETC ColorSource PAR to ensure proper fixture recognition
- **Improve fixture compatibility** for common professional lighting equipment

## Technical Details
- Bulk updates use Prisma transactions for atomicity
- Input validation ensures all specified cues exist before performing updates
- Only provided fields are updated, preserving existing values for omitted properties
- Error messages provide clear feedback for missing cues or invalid operations

## Use Cases
- **Lighting designers** can quickly adjust fade times across multiple cues during rehearsals
- **Bulk operations** reduce API calls and improve performance for large cue lists
- **Enhanced fixture library** supports more professional lighting installations

## Test plan
- [x] Build passes
- [x] Linting passes
- [ ] Test bulk cue updates with multiple cue selection
- [ ] Verify ETC ColorSource fixtures are properly recognized
- [ ] Test error handling for invalid cue IDs
- [ ] Verify transaction rollback on partial failures

🤖 Generated with [Claude Code](https://claude.ai/code)