### PR TITLE
feat: implement real-time cue list playback synchronization

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -37,4 +37,4 @@ export async function createWebSocketContext(): Promise<WebSocketContext> {
   return { prisma, pubsub };
 }
 
-export { pubsub };
+export { prisma, pubsub };

--- a/src/graphql/resolvers/cue.ts
+++ b/src/graphql/resolvers/cue.ts
@@ -1,6 +1,5 @@
 import { Context } from '../../context';
 import { withFilter } from 'graphql-subscriptions';
-import { getPlaybackStateService } from '../../services/playbackStateService';
 
 export const cueResolvers = {
   Query: {

--- a/src/graphql/resolvers/cue.ts
+++ b/src/graphql/resolvers/cue.ts
@@ -1,8 +1,14 @@
 import { Context } from '../../context';
 import { withFilter } from 'graphql-subscriptions';
+import { getPlaybackStateService } from '../../services/playbackStateService';
 
 export const cueResolvers = {
   Query: {
+    cueListPlaybackStatus: async (_: any, { cueListId }: { cueListId: string }) => {
+      const playbackService = getPlaybackStateService();
+      return playbackService.getFormattedStatus(cueListId);
+    },
+
     cueList: async (_: any, { id }: { id: string }, { prisma }: Context) => {
       return prisma.cueList.findUnique({
         where: { id },
@@ -171,6 +177,137 @@ export const cueResolvers = {
         );
       });
 
+      return true;
+    },
+
+    startCueList: async (_: any, { cueListId, startFromCue }: { cueListId: string; startFromCue?: number }, { prisma }: Context) => {
+      const playbackService = getPlaybackStateService();
+
+      // Get the cue list with cues
+      const cueList = await prisma.cueList.findUnique({
+        where: { id: cueListId },
+        include: {
+          cues: {
+            include: { scene: true },
+            orderBy: { cueNumber: 'asc' }
+          }
+        }
+      });
+
+      if (!cueList || cueList.cues.length === 0) {
+        throw new Error('Cue list not found or empty');
+      }
+
+      const startIndex = startFromCue !== undefined ? startFromCue : 0;
+      if (startIndex < 0 || startIndex >= cueList.cues.length) {
+        throw new Error('Invalid cue index');
+      }
+
+      await playbackService.startCue(cueListId, startIndex, cueList.cues[startIndex]);
+      return true;
+    },
+
+    nextCue: async (_: any, { cueListId, fadeInTime }: { cueListId: string; fadeInTime?: number }, { prisma, pubsub }: Context) => {
+      const playbackService = getPlaybackStateService();
+      const currentState = playbackService.getPlaybackState(cueListId);
+
+      if (!currentState || currentState.currentCueIndex === null) {
+        throw new Error('No active playback for this cue list');
+      }
+
+      const nextIndex = currentState.currentCueIndex + 1;
+
+      // Get the cue list to check bounds and get next cue
+      const cueList = await prisma.cueList.findUnique({
+        where: { id: cueListId },
+        include: {
+          cues: {
+            include: { scene: true },
+            orderBy: { cueNumber: 'asc' }
+          }
+        }
+      });
+
+      if (!cueList || nextIndex >= cueList.cues.length) {
+        throw new Error('Already at last cue');
+      }
+
+      const nextCue = cueList.cues[nextIndex];
+
+      // Use the existing playCue logic from dmx resolver
+      const { dmxResolvers } = await import('./dmx');
+      await dmxResolvers.Mutation.playCue(null, { cueId: nextCue.id, fadeInTime }, { prisma, pubsub } as Context);
+
+      return true;
+    },
+
+    previousCue: async (_: any, { cueListId, fadeInTime }: { cueListId: string; fadeInTime?: number }, { prisma, pubsub }: Context) => {
+      const playbackService = getPlaybackStateService();
+      const currentState = playbackService.getPlaybackState(cueListId);
+
+      if (!currentState || currentState.currentCueIndex === null) {
+        throw new Error('No active playback for this cue list');
+      }
+
+      const previousIndex = currentState.currentCueIndex - 1;
+
+      if (previousIndex < 0) {
+        throw new Error('Already at first cue');
+      }
+
+      // Get the cue list to get previous cue
+      const cueList = await prisma.cueList.findUnique({
+        where: { id: cueListId },
+        include: {
+          cues: {
+            include: { scene: true },
+            orderBy: { cueNumber: 'asc' }
+          }
+        }
+      });
+
+      if (!cueList) {
+        throw new Error('Cue list not found');
+      }
+
+      const previousCue = cueList.cues[previousIndex];
+
+      // Use the existing playCue logic from dmx resolver
+      const { dmxResolvers } = await import('./dmx');
+      await dmxResolvers.Mutation.playCue(null, { cueId: previousCue.id, fadeInTime }, { prisma, pubsub } as Context);
+
+      return true;
+    },
+
+    goToCue: async (_: any, { cueListId, cueIndex, fadeInTime }: { cueListId: string; cueIndex: number; fadeInTime?: number }, { prisma, pubsub }: Context) => {
+
+      // Get the cue list
+      const cueList = await prisma.cueList.findUnique({
+        where: { id: cueListId },
+        include: {
+          cues: {
+            include: { scene: true },
+            orderBy: { cueNumber: 'asc' }
+          }
+        }
+      });
+
+      if (!cueList || cueIndex < 0 || cueIndex >= cueList.cues.length) {
+        throw new Error('Invalid cue index');
+      }
+
+      const targetCue = cueList.cues[cueIndex];
+
+      // Use the existing playCue logic from dmx resolver
+      const { dmxResolvers } = await import('./dmx');
+      await dmxResolvers.Mutation.playCue(null, { cueId: targetCue.id, fadeInTime }, { prisma, pubsub } as Context);
+
+      return true;
+    },
+
+    stopCueList: async (_: any, { cueListId }: { cueListId: string }) => {
+      const playbackService = getPlaybackStateService();
+      playbackService.stopCueList(cueListId);
       return true;
     },
 

--- a/src/graphql/resolvers/dmx.ts
+++ b/src/graphql/resolvers/dmx.ts
@@ -163,7 +163,8 @@ export const dmxResolvers = {
       dmxService.clearActiveScene();
 
       // Stop all playback states since we're fading to black
-      // This is handled by the fadeToBlack MCP function which calls the service directly
+      const playbackService = getPlaybackStateService();
+      playbackService.stopAllCueLists();
 
       return true;
     },

--- a/src/graphql/resolvers/dmx.ts
+++ b/src/graphql/resolvers/dmx.ts
@@ -1,6 +1,7 @@
 import { Context } from '../../context';
 import { dmxService } from '../../services/dmx';
 import { fadeEngine, EasingType } from '../../services/fadeEngine';
+import { getPlaybackStateService } from '../../services/playbackStateService';
 
 export const dmxResolvers = {
   Query: {
@@ -88,7 +89,7 @@ export const dmxResolvers = {
     },
 
     playCue: async (_: any, { cueId, fadeInTime }: { cueId: string; fadeInTime?: number }, { prisma }: Context) => {
-      // Get the cue with its scene
+      // Get the cue with its scene and cue list
       const cue = await prisma.cue.findUnique({
         where: { id: cueId },
         include: {
@@ -98,6 +99,13 @@ export const dmxResolvers = {
                 include: {
                   fixture: true,
                 },
+              },
+            },
+          },
+          cueList: {
+            include: {
+              cues: {
+                orderBy: { cueNumber: 'asc' },
               },
             },
           },
@@ -113,15 +121,15 @@ export const dmxResolvers = {
 
       // Build array of all channel values for the scene
       const sceneChannels: Array<{ universe: number; channel: number; value: number }> = [];
-      
+
       for (const fixtureValue of cue.scene.fixtureValues) {
         const fixture = fixtureValue.fixture;
-        
+
         // Iterate through channelValues array by index
         for (let channelIndex = 0; channelIndex < fixtureValue.channelValues.length; channelIndex++) {
           const value = fixtureValue.channelValues[channelIndex];
           const dmxChannel = fixture.startChannel + channelIndex;
-          
+
           sceneChannels.push({
             universe: fixture.universe,
             channel: dmxChannel,
@@ -136,16 +144,29 @@ export const dmxResolvers = {
       // Track the currently active scene (from the cue)
       dmxService.setActiveScene(cue.scene.id);
 
+      // Update playback state service to track cue execution
+      const playbackService = getPlaybackStateService();
+      const cueIndex = cue.cueList.cues.findIndex(c => c.id === cueId);
+
+      if (cueIndex !== -1) {
+        await playbackService.startCue(cue.cueList.id, cueIndex, cue);
+      }
+
       return true;
     },
 
     fadeToBlack: async (_: any, { fadeOutTime }: { fadeOutTime: number }) => {
       // Use fade engine to fade all channels to black
       fadeEngine.fadeToBlack(fadeOutTime);
-      
+
       // Clear the currently active scene since we're fading to black
       dmxService.clearActiveScene();
-      
+
+      // Stop all playback states since we're fading to black
+      const playbackService = getPlaybackStateService();
+      // We need to stop all active cue lists, but we don't have a direct way to get all active states
+      // For now, this is handled by the fadeToBlack MCP function which calls the service directly
+
       return true;
     },
   },

--- a/src/graphql/resolvers/dmx.ts
+++ b/src/graphql/resolvers/dmx.ts
@@ -163,9 +163,7 @@ export const dmxResolvers = {
       dmxService.clearActiveScene();
 
       // Stop all playback states since we're fading to black
-      const playbackService = getPlaybackStateService();
-      // We need to stop all active cue lists, but we don't have a direct way to get all active states
-      // For now, this is handled by the fadeToBlack MCP function which calls the service directly
+      // This is handled by the fadeToBlack MCP function which calls the service directly
 
       return true;
     },

--- a/src/graphql/resolvers/index.ts
+++ b/src/graphql/resolvers/index.ts
@@ -31,10 +31,12 @@ export const resolvers = {
     ...dmxResolvers.Subscription,
     ...projectResolvers.Subscription,
     ...previewResolvers.Subscription,
+    ...cueResolvers.Subscription,
   },
   // Type resolvers
   ...projectResolvers.types,
   ...fixtureResolvers.types,
   ...sceneResolvers.types,
   ...cueResolvers.types,
+  CueListPlaybackStatus: cueResolvers.CueListPlaybackStatus,
 };

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -124,6 +124,15 @@ export const typeDefs = gql`
     notes: String
   }
 
+  type CueListPlaybackStatus {
+    cueListId: ID!
+    currentCueIndex: Int
+    isPlaying: Boolean!
+    currentCue: Cue
+    fadeProgress: Float
+    lastUpdated: String!
+  }
+
   type User {
     id: ID!
     email: String!
@@ -477,5 +486,6 @@ export const typeDefs = gql`
     dmxOutputChanged(universe: Int): UniverseOutput!
     projectUpdated(projectId: ID!): Project!
     previewSessionUpdated(projectId: ID!): PreviewSession!
+    cueListPlaybackUpdated(cueListId: ID!): CueListPlaybackStatus!
   }
 `;

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -408,6 +408,9 @@ export const typeDefs = gql`
     # Active Scene Tracking
     currentActiveScene: Scene
 
+    # Cue List Playback Status
+    cueListPlaybackStatus(cueListId: ID!): CueListPlaybackStatus
+
     # QLC+ Fixture Mapping Suggestions (read-only)
     getQLCFixtureMappingSuggestions(projectId: ID!): QLCFixtureMappingResult!
   }
@@ -475,6 +478,13 @@ export const typeDefs = gql`
     setSceneLive(sceneId: ID!): Boolean!
     playCue(cueId: ID!, fadeInTime: Float): Boolean!
     fadeToBlack(fadeOutTime: Float!): Boolean!
+
+    # Cue List Playback Control
+    startCueList(cueListId: ID!, startFromCue: Int): Boolean!
+    nextCue(cueListId: ID!, fadeInTime: Float): Boolean!
+    previousCue(cueListId: ID!, fadeInTime: Float): Boolean!
+    goToCue(cueListId: ID!, cueIndex: Int!, fadeInTime: Float): Boolean!
+    stopCueList(cueListId: ID!): Boolean!
 
     # QLC+ Import/Export (data-modifying operations)
     importProjectFromQLC(xmlContent: String!, originalFileName: String!): QLCImportResult!

--- a/src/services/playbackStateService.ts
+++ b/src/services/playbackStateService.ts
@@ -1,0 +1,299 @@
+import { PubSub } from 'graphql-subscriptions';
+import { PrismaClient } from '@prisma/client';
+
+export interface PlaybackState {
+  cueListId: string;
+  currentCueIndex: number | null;
+  isPlaying: boolean;
+  currentCue?: CueForPlayback;
+  fadeProgress: number;
+  startTime?: Date;
+  lastUpdated: Date;
+}
+
+interface CueForPlayback {
+  id: string;
+  name: string;
+  cueNumber: number;
+  fadeInTime: number;
+  fadeOutTime: number;
+  followTime?: number | null;
+}
+
+export interface CueListPlaybackStatus {
+  cueListId: string;
+  currentCueIndex: number | null;
+  isPlaying: boolean;
+  currentCue?: CueForPlayback;
+  fadeProgress: number;
+  lastUpdated: string;
+}
+
+class PlaybackStateService {
+  private states = new Map<string, PlaybackState>();
+  private fadeProgressIntervals = new Map<string, NodeJS.Timeout>();
+  private followTimeouts = new Map<string, NodeJS.Timeout>();
+
+  constructor(
+    private prisma: PrismaClient,
+    private pubsub: PubSub
+  ) {}
+
+  // Get current playback state for a cue list
+  getPlaybackState(cueListId: string): PlaybackState | null {
+    return this.states.get(cueListId) || null;
+  }
+
+  // Start playing a cue
+  async startCue(cueListId: string, cueIndex: number, cue: CueForPlayback): Promise<void> {
+    // Clear any existing state for this cue list
+    this.stopCueList(cueListId);
+
+    const state: PlaybackState = {
+      cueListId,
+      currentCueIndex: cueIndex,
+      isPlaying: true,
+      currentCue: {
+        id: cue.id,
+        name: cue.name,
+        cueNumber: cue.cueNumber,
+        fadeInTime: cue.fadeInTime,
+        fadeOutTime: cue.fadeOutTime,
+        followTime: cue.followTime,
+      },
+      fadeProgress: 0,
+      startTime: new Date(),
+      lastUpdated: new Date(),
+    };
+
+    this.states.set(cueListId, state);
+
+    // Start fade progress tracking
+    this.startFadeProgress(cueListId, cue.fadeInTime);
+
+    // Emit subscription update
+    this.emitUpdate(cueListId);
+
+    // Schedule follow time if applicable
+    if (cue.followTime && cue.followTime > 0) {
+      const totalWaitTime = (cue.fadeInTime + cue.followTime) * 1000;
+
+      const followTimeout = setTimeout(async () => {
+        await this.handleFollowTime(cueListId, cueIndex);
+      }, totalWaitTime);
+
+      this.followTimeouts.set(cueListId, followTimeout);
+    } else {
+      // Mark as not playing after fade completes
+      setTimeout(() => {
+        const currentState = this.states.get(cueListId);
+        if (currentState && currentState.currentCueIndex === cueIndex) {
+          currentState.isPlaying = false;
+          currentState.lastUpdated = new Date();
+          this.emitUpdate(cueListId);
+        }
+      }, cue.fadeInTime * 1000);
+    }
+  }
+
+  // Handle automatic follow to next cue
+  private async handleFollowTime(cueListId: string, currentCueIndex: number): Promise<void> {
+    try {
+      // Get the cue list and find the next cue
+      const cueList = await this.prisma.cueList.findUnique({
+        where: { id: cueListId },
+        include: {
+          cues: {
+            include: { scene: true },
+            orderBy: { cueNumber: 'asc' }
+          }
+        }
+      });
+
+      if (!cueList || currentCueIndex + 1 >= cueList.cues.length) {
+        // No next cue, mark as stopped
+        const state = this.states.get(cueListId);
+        if (state) {
+          state.isPlaying = false;
+          state.lastUpdated = new Date();
+          this.emitUpdate(cueListId);
+        }
+        return;
+      }
+
+      const nextCue = cueList.cues[currentCueIndex + 1];
+      await this.startCue(cueListId, currentCueIndex + 1, nextCue);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error handling follow time:', error);
+      this.stopCueList(cueListId);
+    }
+  }
+
+  // Stop playback for a cue list
+  stopCueList(cueListId: string): void {
+    // Clear intervals and timeouts
+    const fadeInterval = this.fadeProgressIntervals.get(cueListId);
+    if (fadeInterval) {
+      clearInterval(fadeInterval);
+      this.fadeProgressIntervals.delete(cueListId);
+    }
+
+    const followTimeout = this.followTimeouts.get(cueListId);
+    if (followTimeout) {
+      clearTimeout(followTimeout);
+      this.followTimeouts.delete(cueListId);
+    }
+
+    // Update state
+    const state = this.states.get(cueListId);
+    if (state) {
+      state.isPlaying = false;
+      state.fadeProgress = 0;
+      state.lastUpdated = new Date();
+      this.emitUpdate(cueListId);
+    }
+  }
+
+  // Jump to a specific cue
+  async jumpToCue(cueListId: string, cueIndex: number): Promise<void> {
+    try {
+      const cueList = await this.prisma.cueList.findUnique({
+        where: { id: cueListId },
+        include: {
+          cues: {
+            include: { scene: true },
+            orderBy: { cueNumber: 'asc' }
+          }
+        }
+      });
+
+      if (!cueList || cueIndex >= cueList.cues.length || cueIndex < 0) {
+        throw new Error('Invalid cue index');
+      }
+
+      const cue = cueList.cues[cueIndex];
+      await this.startCue(cueListId, cueIndex, cue);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error jumping to cue:', error);
+      throw error;
+    }
+  }
+
+  // Start tracking fade progress
+  private startFadeProgress(cueListId: string, fadeTime: number): void {
+    const state = this.states.get(cueListId);
+    if (!state) {
+      return;
+    }
+
+    const startTime = Date.now();
+    const interval = setInterval(() => {
+      const currentState = this.states.get(cueListId);
+      if (!currentState) {
+        clearInterval(interval);
+        return;
+      }
+
+      const elapsed = Date.now() - startTime;
+      const progress = Math.min((elapsed / (fadeTime * 1000)) * 100, 100);
+
+      currentState.fadeProgress = progress;
+      currentState.lastUpdated = new Date();
+
+      // Emit update periodically during fade
+      this.emitUpdate(cueListId);
+
+      if (progress >= 100) {
+        clearInterval(interval);
+        this.fadeProgressIntervals.delete(cueListId);
+      }
+    }, 100); // Update every 100ms
+
+    this.fadeProgressIntervals.set(cueListId, interval);
+  }
+
+  // Emit subscription update
+  private emitUpdate(cueListId: string): void {
+    const state = this.states.get(cueListId);
+    if (!state) {
+      return;
+    }
+
+    const status: CueListPlaybackStatus = {
+      cueListId: state.cueListId,
+      currentCueIndex: state.currentCueIndex,
+      isPlaying: state.isPlaying,
+      currentCue: state.currentCue,
+      fadeProgress: state.fadeProgress,
+      lastUpdated: state.lastUpdated.toISOString(),
+    };
+
+    this.pubsub.publish(`CUE_LIST_PLAYBACK_UPDATED_${cueListId}`, {
+      cueListPlaybackUpdated: status,
+    });
+  }
+
+  // Get formatted status for GraphQL response
+  getFormattedStatus(cueListId: string): CueListPlaybackStatus | null {
+    const state = this.states.get(cueListId);
+    if (!state) {
+      return {
+        cueListId,
+        currentCueIndex: null,
+        isPlaying: false,
+        currentCue: undefined,
+        fadeProgress: 0,
+        lastUpdated: new Date().toISOString(),
+      };
+    }
+
+    return {
+      cueListId: state.cueListId,
+      currentCueIndex: state.currentCueIndex,
+      isPlaying: state.isPlaying,
+      currentCue: state.currentCue,
+      fadeProgress: state.fadeProgress,
+      lastUpdated: state.lastUpdated.toISOString(),
+    };
+  }
+
+  // Cleanup method
+  cleanup(): void {
+    // Clear all intervals and timeouts
+    for (const interval of this.fadeProgressIntervals.values()) {
+      clearInterval(interval);
+    }
+    for (const timeout of this.followTimeouts.values()) {
+      clearTimeout(timeout);
+    }
+
+    this.fadeProgressIntervals.clear();
+    this.followTimeouts.clear();
+    this.states.clear();
+  }
+}
+
+// Singleton instance
+let playbackStateServiceInstance: PlaybackStateService | null = null;
+
+export function getPlaybackStateService(): PlaybackStateService {
+  if (!playbackStateServiceInstance) {
+    // Dynamic imports to avoid circular dependency
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { PubSub } = require('graphql-subscriptions');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { PrismaClient } = require('@prisma/client');
+
+    playbackStateServiceInstance = new PlaybackStateService(
+      new PrismaClient(),
+      new PubSub()
+    );
+  }
+  return playbackStateServiceInstance;
+}
+
+export function setPlaybackStateService(service: PlaybackStateService): void {
+  playbackStateServiceInstance = service;
+}

--- a/src/services/playbackStateService.ts
+++ b/src/services/playbackStateService.ts
@@ -155,6 +155,17 @@ class PlaybackStateService {
     }
   }
 
+  // Stop all cue lists (for fadeToBlack scenarios)
+  stopAllCueLists(): void {
+    // Get all active cue list IDs
+    const cueListIds = Array.from(this.states.keys());
+
+    // Stop each cue list individually to ensure proper cleanup and notifications
+    for (const cueListId of cueListIds) {
+      this.stopCueList(cueListId);
+    }
+  }
+
   // Jump to a specific cue
   async jumpToCue(cueListId: string, cueIndex: number): Promise<void> {
     try {
@@ -280,12 +291,7 @@ let playbackStateServiceInstance: PlaybackStateService | null = null;
 
 export function getPlaybackStateService(): PlaybackStateService {
   if (!playbackStateServiceInstance) {
-    // Dynamic imports to avoid circular dependency
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { PubSub } = require('graphql-subscriptions');
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { PrismaClient } = require('@prisma/client');
-
+    // Use already imported modules from top of file
     playbackStateServiceInstance = new PlaybackStateService(
       new PrismaClient(),
       new PubSub()

--- a/src/services/playbackStateService.ts
+++ b/src/services/playbackStateService.ts
@@ -1,5 +1,6 @@
 import { PubSub } from 'graphql-subscriptions';
 import { PrismaClient } from '@prisma/client';
+import { prisma, pubsub } from '../context';
 
 export interface PlaybackState {
   cueListId: string;
@@ -291,10 +292,10 @@ let playbackStateServiceInstance: PlaybackStateService | null = null;
 
 export function getPlaybackStateService(): PlaybackStateService {
   if (!playbackStateServiceInstance) {
-    // Use already imported modules from top of file
+    // Use shared singleton instances from context
     playbackStateServiceInstance = new PlaybackStateService(
-      new PrismaClient(),
-      new PubSub()
+      prisma,
+      pubsub
     );
   }
   return playbackStateServiceInstance;


### PR DESCRIPTION
## Summary
• Added GraphQL subscriptions for real-time cue list playback synchronization across multiple clients
• Implemented centralized playback state management with fade progress tracking
• Enhanced playCue mutation to emit live state updates via WebSocket subscriptions

## Technical Implementation
• **PlaybackStateService**: Singleton service managing playback state across all cue lists
• **GraphQL Subscriptions**: WebSocket-based real-time updates with cue list filtering
• **Fade Progress Tracking**: 100ms interval updates during fade transitions
• **Auto-follow Handling**: Automatic sequential cue execution with follow-time support
• **Type Safety**: Proper TypeScript interfaces for all playback state objects

## Test Plan
- [ ] Verify GraphQL subscription connects and receives events
- [ ] Test real-time fade progress updates across multiple browser tabs
- [ ] Confirm follow-time automation triggers next cue correctly
- [ ] Validate state synchronization when multiple clients play different cues
- [ ] Test subscription cleanup when clients disconnect

🤖 Generated with [Claude Code](https://claude.ai/code)