### PR TITLE
Add dev:interactive script to fix tsx watch stdin conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "tsx watch src/index.ts",
+    "dev:interactive": "tsx src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "stop": "pkill -f 'node dist/index.js' || echo 'Server not running'",


### PR DESCRIPTION
## Summary
- Added `dev:interactive` script to run tsx without watch mode for interactive Art-Net interface selection
- Fixes issue where tsx watch intercepts Enter key, causing application to restart instead of reading user input

## Problem
When running `npm run dev`, tsx watch monitors stdin for restart commands. Pressing Enter triggers a restart instead of submitting the user's interface selection, making interactive prompts unusable.

## Solution
Added `npm run dev:interactive` that runs tsx without watch mode, allowing interactive prompts to work correctly. For regular development with auto-reload, developers can set `ARTNET_BROADCAST` in their `.env` file and continue using `npm run dev`.

## Test plan
- [x] Run `npm run dev:interactive` and verify interface selection works
- [x] Verify `npm run dev` still works with `ARTNET_BROADCAST` env var set
- [x] Build passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)